### PR TITLE
Can't use MathLink in github action

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,4 +1,10 @@
 name: CI
+
+# github action doesn't have MathLink installed
+# https://github.com/JuliaInterop/MathLink.jl#installation-troubleshoot
+env:
+  JULIA_MATHKERNEL: ""
+
 on:
   push:
     branches:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -3,7 +3,7 @@ name: CI
 # github action doesn't have MathLink installed
 # https://github.com/JuliaInterop/MathLink.jl#installation-troubleshoot
 env:
-  JULIA_MATHKERNEL: ""
+  JULIA_MATHKERNEL:
 
 on:
   push:

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -3,6 +3,13 @@ using Documenter
 
 DocMeta.setdocmeta!(WolframExpr, :DocTestSetup, :(using WolframExpr); recursive = true)
 
+doctest = if haskey(ENV, "GITHUB_ACTIONS")
+    @warn "Tests disabled in github actions"
+    false
+else
+    true
+end
+
 makedocs(;
     modules = [WolframExpr],
     authors = "Nathan Musoke <nathan.musoke@gmail.com> and contributors",
@@ -15,6 +22,7 @@ makedocs(;
         assets = String[],
     ),
     pages = ["Home" => "index.md"],
+    doctest = doctest,
 )
 
 deploydocs(; repo = "github.com/musoke/WolframExpr.jl", devbranch = "main")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,11 @@ using WolframExpr
 using Test
 using Documenter
 
+if haskey(ENV, "GITHUB_ACTIONS")
+    @warn "Tests disabled in github actions"
+    return
+end
+
 doctest(WolframExpr)
 
 @testset "WolframExpr.jl" begin


### PR DESCRIPTION
- tell MathLink.jl to install without links
- don't run tests