### PR TITLE
feat: Sqrt -> sqrt

### DIFF
--- a/src/WolframExpr.jl
+++ b/src/WolframExpr.jl
@@ -143,6 +143,8 @@ function wexpr_to_expr(expr::MathLink.WExpr)::Expr
         return Expr(:call, :^, map(wexpr_to_expr, expr.args)...)
     elseif expr.head.name == "Rational"
         return Expr(:call, ://, map(wexpr_to_expr, expr.args)...)
+    elseif expr.head.name == "Sqrt"
+        return Expr(:call, :sqrt, map(wexpr_to_expr, expr.args)...)
     elseif expr.head.name == "Complex"
         @assert length(expr.args) == 2
         return Expr(:call, :Complex, map(wexpr_to_expr, expr.args)...)

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -20,5 +20,8 @@ f = string_to_function("1.+2I", [])
 f = WolframExpr.string_to_function("x+y", [:x, :y])
 @test f(1.2, 2) === 3.2
 
+f = WolframExpr.string_to_function("Sqrt[x]", [:x])
+@test f(2) === sqrt(2)
+
 string_derivative = raw"""Derivative[0,1][f][x,y]"""
 @test string_to_expr(string_derivative) == :(Derivative_0_1_f(x, y))


### PR DESCRIPTION
Add a mapping from Wolfram's `Sqrt` to Julia's `sqrt`.

This is correct for non-negative numbers but may have inconsistent results for some complex arguments or output.