### PR TITLE
Bump julia-actions/cache from v1.4.1 to v2

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -75,6 +75,7 @@ jobs:
       - uses: julia-actions/setup-julia@v1
         with:
           version: '1'
+      - uses: julia-actions/cache@v1.4.1
       - name: Configure doc environment
         run: |
           julia --project=docs/ -e '

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -37,6 +37,9 @@ jobs:
     # Limit runtime to preserve Wolfram Service Credits
     timeout-minutes: 10
     steps:
+      - name: Install curl
+        # julia-actions/cache depends on dcarbone/install-jq-action, which requires curl
+        run: apt-get update && apt-get install -y curl
       - uses: actions/checkout@v3
       - uses: julia-actions/setup-julia@v1
         with:
@@ -47,7 +50,7 @@ jobs:
           apt-get update
           apt-get install -y git
           which git
-      - uses: julia-actions/cache@v1.4.1
+      - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
@@ -71,11 +74,14 @@ jobs:
       contents: write
       statuses: write
     steps:
+      - name: Install curl
+        # julia-actions/cache depends on dcarbone/install-jq-action, which requires curl
+        run: apt-get update && apt-get install -y curl
       - uses: actions/checkout@v3
       - uses: julia-actions/setup-julia@v1
         with:
           version: '1'
-      - uses: julia-actions/cache@v1.4.1
+      - uses: julia-actions/cache@v2
       - name: Configure doc environment
         run: |
           julia --project=docs/ -e '


### PR DESCRIPTION
Accidentally merged the previous version of this (#29) before it was ready.  Try again...


waiting on a new tagged version of julia-actions/cache.